### PR TITLE
2 add data classes etc for loading pipeline annotated datasets

### DIFF
--- a/enunlg/data_management/e2e_challenge.py
+++ b/enunlg/data_management/e2e_challenge.py
@@ -5,6 +5,7 @@ import csv
 import os
 
 import box
+import omegaconf
 import regex
 
 import enunlg.data_management.iocorpus as iocorpus
@@ -13,9 +14,10 @@ import enunlg.data_management.iocorpus as iocorpus
 E2E_DIR = os.path.join(os.path.dirname(__file__), '../../datasets/e2e-dataset/')
 E2E_CLEANED_DIR = os.path.join(os.path.dirname(__file__), '../../datasets/e2e-cleaning/cleaned-data/')
 
-E2E_CONFIG = box.Box({'E2E_DIR': os.path.join(os.path.dirname(__file__), '../../datasets/raw/e2e-dataset/'),
-                      'E2E_CLEANED_DIR': os.path.join(os.path.dirname(__file__),
-                                                      '../../datasets/raw/e2e-cleaning/cleaned-data/')})
+E2E_CONFIG = omegaconf.DictConfig({'E2E_DIR': os.path.join(os.path.dirname(__file__),
+                                                           '../../datasets/raw/e2e-dataset/'),
+                                   'E2E_CLEANED_DIR': os.path.join(os.path.dirname(__file__),
+                                                                   '../../datasets/raw/e2e-cleaning/cleaned-data/')})
 
 E2E_SPLITS = ('trainset', 'devset', 'testset_w_refs')
 E2E_CLEANED_SPLITS = ('train-fixed.no-ol', 'devel-fixed.no-ol', 'test-fixed')
@@ -95,7 +97,7 @@ def load_e2e_csv(filepath: str) -> List[Tuple[str, str]]:
 
 def load_e2e(splits: Optional[Iterable[str]] = None,
              original: bool = True,
-             e2e_config: Optional[box.Box] = None) -> E2ECorpus:
+             e2e_config: Optional[omegaconf.DictConfig] = None) -> E2ECorpus:
     """
 
     :param splits: which splits to load

--- a/enunlg/data_management/enriched_e2e.py
+++ b/enunlg/data_management/enriched_e2e.py
@@ -1,17 +1,18 @@
+from collections import defaultdict
 from typing import Callable, Dict, Iterable, List, Optional, Union
 
+import difflib
 import logging
 import os
+import random
 
-import box
 import omegaconf
 import xsdata.formats.dataclass.parsers as xsparsers
 
 from enunlg.formats.xml.enriched_e2e import EnrichedE2EEntries
+from enunlg.meaning_representation.slot_value import SlotValueMR
 import enunlg.data_management.iocorpus
 import enunlg.data_management.pipelinecorpus
-
-logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
 
 # TODO add hydra configuration for enriched e2e stuff
 ENRICHED_E2E_CONFIG = omegaconf.DictConfig({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(__file__),
@@ -22,6 +23,31 @@ E2E_SPLIT_DIRS = ('train', 'dev', 'test')
 DELEX_LABELS = ["__AREA__", "__CUSTOMER_RATING__", "__EATTYPE__", "__FAMILYFRIENDLY__", "__FOOD__", "__NAME__",
                 "__NEAR__", "__PRICERANGE__"]
 
+DIFFER = difflib.Differ()
+
+
+def extract_reg_from_template_and_text(text, template):
+    diff = DIFFER.compare(text, template)
+    keys = []
+    values = []
+    curr_add = []
+    curr_min = []
+    for x in diff:
+        if x.startswith('-'):
+            curr_min.append(x[2])
+        elif x.startswith('+'):
+            curr_add.append(x[2])
+        else:
+            if curr_min:
+                values.append("".join(curr_min))
+                curr_min = []
+            if curr_add:
+                keys.append("".join(curr_add))
+                curr_add = []
+    result_dict = defaultdict(list)
+    for key, value in zip(keys, values):
+        result_dict[key].append(value)
+    return result_dict
 
 class EnrichedE2ECorpusRaw(enunlg.data_management.iocorpus.IOCorpus):
     def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None):
@@ -53,10 +79,9 @@ class PipelineCorpusMapper(object):
         self.input_format = input_format
         self.output_format = output_format
         self.annotation_layer_mappings = annotation_layer_mappings
-        logging.info('successful init')
 
-    def __call__(self, input_corpus):
-        logging.debug('successful call')
+    def __call__(self, input_corpus: Iterable) -> List:
+        logging.debug(f'successful call to {self.__class__.__name__} as a function (rather than a class)')
         if isinstance(input_corpus, self.input_format):
             logging.debug('passed the format check')
             output_seq = []
@@ -65,13 +90,16 @@ class PipelineCorpusMapper(object):
                 for layer in self.annotation_layer_mappings:
                     logging.debug(f"processing {layer}")
                     output.append(self.annotation_layer_mappings[layer](entry))
-                max_length = max([len(x) for x in output])
-                output = [x * max_length if len(x) == 1 else x for x in output]
-                assert all([len(x) == max_length for x in output]), f"expected all layers to have the same number of items, but received: {[len(x) for x in output]}"
-                for i in range(max_length-1):
+                # EnrichedE2E-formated datasets have up to N distinct targets for each single input
+                # This will show up as the first 'layer' having length 1 and subsequent layers having length > 1
+                num_targets = max([len(x) for x in output])
+                # We expand any layers of length 1, duplicating their entries, and preserving the rest of the layers
+                output = [x * num_targets if len(x) == 1 else x for x in output]
+                assert all([len(x) == num_targets for x in output]), f"expected all layers to have the same number of items, but received: {[len(x) for x in output]}"
+                # For each of the N distinct targets, create a self.outputformat object and append it to the output_seq
+                for i in range(num_targets-1):
                     item = self.output_format({key: output[idx][i] for idx, key in enumerate(self.annotation_layer_mappings.keys())})
                     output_seq.append(item)
-                output_seq.append(output)
                 logging.debug(f"Num entries so far: {len(output_seq)}")
             return output_seq
         else:
@@ -97,15 +125,7 @@ class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
     def __init__(self, seq: List[EnrichedE2EItem]):
         if seq:
             layer_names = seq[0].layers
-            try:
-                for idx, item in enumerate(seq):
-                    if isinstance(item, list):
-                        print(idx)
-                        print(item)
-                        raise AttributeError
-                assert all([item.layers == layer_names for item in seq]), f"Expected all items in seq to have the layers: {layer_names}"
-            except AttributeError:
-                raise
+            assert all([item.layers == layer_names for item in seq]), f"Expected all items in seq to have the layers: {layer_names}"
             self.layers = layer_names
         super(EnrichedE2ECorpus, self).__init__(seq)
 
@@ -113,12 +133,16 @@ class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
     def views(self):
         return [(l1, l2) for l1, l2 in zip(self.layers, self.layers[1:])]
 
+    def items_by_view(self, view):
+        for item in self:
+            yield item[view[0]], item[view[1]]
+
 
 def extract_raw_input(entry):
     mr = {}
     for input in entry.source.inputs:
         mr[input.attribute] = input.value
-    return [box.Box(mr)]
+    return [SlotValueMR(mr, frozen_box=True)]
 
 
 def extract_selected_input(entry):
@@ -128,7 +152,7 @@ def extract_selected_input(entry):
         for sentence in target.structuring.sentences:
             for input in sentence.content:
                 mr[input.attribute] = input.value
-        targets.append(box.Box(mr))
+        targets.append(SlotValueMR(mr, frozen_box=True))
     return targets
 
 
@@ -140,8 +164,8 @@ def extract_ordered_input(entry):
             mr = {}
             for input in sentence.content:
                 mr[input.attribute] = input.value
-            selected_inputs.append(box.Box(mr))
-        targets.append(selected_inputs)
+            selected_inputs.append(SlotValueMR(mr, frozen_box=True))
+        targets.append(tuple(selected_inputs))
     return targets
 
 
@@ -153,8 +177,8 @@ def extract_sentence_segmented_input(entry):
             mr = {}
             for input in sentence.content:
                 mr[input.attribute] = input.value
-            selected_inputs.append(box.Box(mr))
-        targets.append(selected_inputs)
+            selected_inputs.append(SlotValueMR(mr, frozen_box=True))
+        targets.append(tuple(selected_inputs))
     return targets
 
 
@@ -162,15 +186,29 @@ def extract_lexicalization(entry):
     return [target.lexicalization for target in entry.targets]
 
 
+def extract_reg_completed_lex_random(entry):
+    texts = [target.text for target in entry.targets]
+    templates = [target.template for target in entry.targets]
+    texts_templates = zip(texts, templates)
+    lexes = [target.lexicalization for target in entry.targets]
+    regged_lexes = []
+    for pair, lex in zip(texts_templates, lexes):
+        reg_dict = extract_reg_from_template_and_text(pair[0], pair[1])
+        for key in reg_dict:
+            lex = lex.replace(key, random.choice(reg_dict[key]))
+        regged_lexes.append(lex)
+    return regged_lexes
+
+
 def extract_raw_output(entry):
     return [target.text for target in entry.targets]
 
 
-def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_config: Optional[box.Box] = None) -> EnrichedE2ECorpus:
+def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_config: Optional[SlotValueMR] = None) -> EnrichedE2ECorpus:
     """
 
     :param splits: which splits to load
-    :param enriched_e2e_config: a box.Box or omegaconf.DictConfig like object containing the basic
+    :param enriched_e2e_config: a SlotValueMR or omegaconf.DictConfig like object containing the basic
                                 information about the e2e corpus to be used
     :return: the corpus of MR-text pairs with metadata
     """
@@ -201,7 +239,7 @@ def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_confi
                                                  'ordered-input': extract_ordered_input,
                                                  'sentence-segmented-input': extract_sentence_segmented_input,
                                                  'lexicalisation': extract_lexicalization,
-                                                 'referring-expressions': lambda x: [None],
+                                                 'referring-expressions': extract_reg_completed_lex_random,
                                                  'raw-output': extract_raw_output})
 
     corpus = EnrichedE2ECorpus(enriched_e2e_factory(corpus))

--- a/enunlg/data_management/enriched_e2e.py
+++ b/enunlg/data_management/enriched_e2e.py
@@ -1,15 +1,17 @@
+import os
 from typing import Iterable, List, Optional, Union
 
+import box
 import xsdata.formats.dataclass.parsers as xsparsers
 
 from enunlg.formats.xml.enriched_e2e import Entries
 import enunlg.data_management.iocorpus
 
-# from enlg.data_management.pipelinecorpus import PipelineCorpus
 
-# class EnrichedE2E(PipelineCorpus):
-#     def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None):
-#         super().__init__(seq, filename_or_list, validation_schema = 'enlg/formats/enriched_e2e.xsd', entry_class: Optional[Callable] = None)
+# TODO add hydra configuration for enriched e2e stuff
+ENRICHED_E2E_CONFIG = box.Box({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(__file__), '../../datasets/raw/EnrichedE2E/')})
+
+E2E_SPLIT_DIRS = ('train', 'dev', 'test')
 
 
 class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
@@ -21,6 +23,7 @@ class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
         if filename_or_list is not None:
             if isinstance(filename_or_list, list):
                 for filename in filename_or_list:
+                    print(filename)
                     self.load_file(filename)
             elif isinstance(filename_or_list, str):
                 self.load_file(filename_or_list)
@@ -32,8 +35,30 @@ class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
         self.entries.extend(entries_object.entry)
 
 
-if __name__ == "__main__":
-    tmp = EnrichedE2ECorpus()
-    tmp.load_file('datasets/raw/EnrichedE2E/train/8attributes.xml')
-    for x in tmp.entries[:10]:
-        print(x)
+def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_config: Optional[box.Box] = None) -> EnrichedE2ECorpus:
+    """
+
+    :param splits: which splits to load
+    :param enriched_e2e_config: a box.Box or omegaconf.DictConfig like object containing the basic
+                                information about the e2e corpus to be used
+    :return: the corpus of MR-text pairs with metadata
+    """
+    if enriched_e2e_config is None:
+        enriched_e2e_config = ENRICHED_E2E_CONFIG
+    corpus_name = "E2E Challenge Corpus"
+    default_splits = E2E_SPLIT_DIRS
+    data_directory = enriched_e2e_config.ENRICHED_E2E_DIR
+    if splits is None:
+        splits = default_splits
+    elif not set(splits).issubset(default_splits):
+        raise ValueError(f"`splits` can only contain a subset of {default_splits}. Found {splits}.")
+    fns = []
+    for split in splits:
+        print(split)
+        fns.extend([os.path.join(data_directory, split, fn) for fn in os.listdir(os.path.join(data_directory, split))])
+
+    corpus = EnrichedE2ECorpus(filename_or_list=fns)
+    corpus.metadata = {'name': corpus_name,
+                       'splits': splits,
+                       'directory': data_directory}
+    return corpus

--- a/enunlg/data_management/enriched_e2e.py
+++ b/enunlg/data_management/enriched_e2e.py
@@ -1,12 +1,16 @@
+from typing import Callable, Dict, Iterable, List, Optional, Union
+
+import logging
 import os
-from typing import Iterable, List, Optional, Union
 
 import box
 import xsdata.formats.dataclass.parsers as xsparsers
 
-from enunlg.formats.xml.enriched_e2e import Entries
+from enunlg.formats.xml.enriched_e2e import EnrichedE2EEntries
 import enunlg.data_management.iocorpus
+import enunlg.data_management.pipelinecorpus
 
+logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
 
 # TODO add hydra configuration for enriched e2e stuff
 ENRICHED_E2E_CONFIG = box.Box({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(__file__), '../../datasets/raw/EnrichedE2E/')})
@@ -14,7 +18,7 @@ ENRICHED_E2E_CONFIG = box.Box({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(
 E2E_SPLIT_DIRS = ('train', 'dev', 'test')
 
 
-class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
+class EnrichedE2ECorpusRaw(enunlg.data_management.iocorpus.IOCorpus):
     def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None):
         if seq is None:
             seq = []
@@ -23,19 +27,50 @@ class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
         if filename_or_list is not None:
             if isinstance(filename_or_list, list):
                 for filename in filename_or_list:
-                    print(filename)
+                    logging.info(filename)
                     self.load_file(filename)
             elif isinstance(filename_or_list, str):
                 self.load_file(filename_or_list)
             else:
                 raise TypeError(f"Expected filename_or_list to be None, str, or list, not {type(filename_or_list)}")
+            self.extend(self.entries)
 
     def load_file(self, filename):
-        entries_object = xsparsers.XmlParser().parse(filename, Entries)
-        self.entries.extend(entries_object.entry)
+        entries_object = xsparsers.XmlParser().parse(filename, EnrichedE2EEntries)
+        self.entries.extend(entries_object.entries)
 
 
-def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_config: Optional[box.Box] = None) -> EnrichedE2ECorpus:
+class PipelineCorpusMapper(object):
+    def __init__(self, input_format, output_format, annotation_layer_mappings: Dict[str, Callable]):
+        """
+        Create a function which will map from `input_format` to `output_format` using `annotation_layer_mappings`.
+        """
+        self.input_format = input_format
+        self.output_format = output_format
+        self.annotation_layer_mappings = annotation_layer_mappings
+        logging.info('successful init')
+
+    def __call__(self, input_corpus):
+        logging.info('successful call')
+        if isinstance(input_corpus, self.input_format):
+            logging.info('passed the format check')
+            output_seq = []
+            for x in input_corpus:
+                output = []
+                for layer in self.annotation_layer_mappings:
+                    logging.info(f"processing {layer}")
+                    output.append(self.annotation_layer_mappings[layer](x))
+                max_length = max([len(x) for x in output])
+                output = [x * max_length if len(x) == 1 else x for x in output]
+                assert all([len(x) == max_length for x in output]), f"expected all layers to have the same number of items, but received: {[len(x) for x in output]}"
+                output_seq.append(output)
+                logging.info(len(output_seq))
+            return self.output_format(output_seq)
+        else:
+            raise TypeError(f"Cannot run {self.__class__} on {type(input_corpus)}")
+
+
+def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_config: Optional[box.Box] = None) -> EnrichedE2ECorpusRaw:
     """
 
     :param splits: which splits to load
@@ -54,11 +89,49 @@ def load_enriched_e2e(splits: Optional[Iterable[str]] = None, enriched_e2e_confi
         raise ValueError(f"`splits` can only contain a subset of {default_splits}. Found {splits}.")
     fns = []
     for split in splits:
-        print(split)
+        logging.info(split)
         fns.extend([os.path.join(data_directory, split, fn) for fn in os.listdir(os.path.join(data_directory, split))])
 
-    corpus = EnrichedE2ECorpus(filename_or_list=fns)
+    corpus = EnrichedE2ECorpusRaw(filename_or_list=fns)
     corpus.metadata = {'name': corpus_name,
                        'splits': splits,
                        'directory': data_directory}
+    logging.info(len(corpus))
+    #lambda entry: [x.sentence.content for x in entry.targets.structuring]
+
+    def extract_ordered_input(entry):
+        targets = []
+        for target in entry.targets:
+            selected_inputs = []
+            for sentence in target.structuring.sentences:
+                selected_inputs.extend(sentence.content)
+            targets.append(selected_inputs)
+        return targets
+
+    def extract_sentence_segmented_input(entry):
+        targets = []
+        for target in entry.targets:
+            selected_inputs = []
+            for sentence in target.structuring.sentences:
+                selected_inputs.append(sentence.content)
+            targets.append(selected_inputs)
+        return targets
+
+    def extract_lexicalization(entry):
+        return [target.lexicalization for target in entry.targets]
+
+    def extract_raw_output(entry):
+        return [target.text for target in entry.targets]
+
+    enriched_e2e_factory = PipelineCorpusMapper(EnrichedE2ECorpusRaw, enunlg.data_management.iocorpus.IOCorpus,
+                                                {'raw-input': lambda entry: [entry.source.inputs],
+                                                 'selected-input': lambda entry: [set(x) for x in extract_ordered_input(entry)],
+                                                 'ordered-input': extract_ordered_input,
+                                                 'sentence-segmented-input': extract_sentence_segmented_input,
+                                                 'lexicalisation': extract_lexicalization,
+                                                 'referring-expressions': lambda x: [None],
+                                                 'raw-output': extract_raw_output})
+    logging.info(len(corpus))
+    corpus = enriched_e2e_factory(corpus)
+    logging.info(len(corpus))
     return corpus

--- a/enunlg/data_management/enriched_e2e.py
+++ b/enunlg/data_management/enriched_e2e.py
@@ -1,0 +1,39 @@
+from typing import Iterable, List, Optional, Union
+
+import xsdata.formats.dataclass.parsers as xsparsers
+
+from enunlg.formats.xml.enriched_e2e import Entries
+import enunlg.data_management.iocorpus
+
+# from enlg.data_management.pipelinecorpus import PipelineCorpus
+
+# class EnrichedE2E(PipelineCorpus):
+#     def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None):
+#         super().__init__(seq, filename_or_list, validation_schema = 'enlg/formats/enriched_e2e.xsd', entry_class: Optional[Callable] = None)
+
+
+class EnrichedE2ECorpus(enunlg.data_management.iocorpus.IOCorpus):
+    def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None):
+        if seq is None:
+            seq = []
+        super().__init__(seq)
+        self.entries = []
+        if filename_or_list is not None:
+            if isinstance(filename_or_list, list):
+                for filename in filename_or_list:
+                    self.load_file(filename)
+            elif isinstance(filename_or_list, str):
+                self.load_file(filename_or_list)
+            else:
+                raise TypeError(f"Expected filename_or_list to be None, str, or list, not {type(filename_or_list)}")
+
+    def load_file(self, filename):
+        entries_object = xsparsers.XmlParser().parse(filename, Entries)
+        self.entries.extend(entries_object.entry)
+
+
+if __name__ == "__main__":
+    tmp = EnrichedE2ECorpus()
+    tmp.load_file('datasets/raw/EnrichedE2E/train/8attributes.xml')
+    for x in tmp.entries[:10]:
+        print(x)

--- a/enunlg/data_management/enriched_e2e.py
+++ b/enunlg/data_management/enriched_e2e.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import box
+import omegaconf
 import xsdata.formats.dataclass.parsers as xsparsers
 
 from enunlg.formats.xml.enriched_e2e import EnrichedE2EEntries
@@ -13,7 +14,8 @@ import enunlg.data_management.pipelinecorpus
 logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
 
 # TODO add hydra configuration for enriched e2e stuff
-ENRICHED_E2E_CONFIG = box.Box({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(__file__), '../../datasets/raw/EnrichedE2E/')})
+ENRICHED_E2E_CONFIG = omegaconf.DictConfig({'ENRICHED_E2E_DIR': os.path.join(os.path.dirname(__file__),
+                                                                             '../../datasets/raw/EnrichedE2E/')})
 
 E2E_SPLIT_DIRS = ('train', 'dev', 'test')
 

--- a/enunlg/data_management/iocorpus.py
+++ b/enunlg/data_management/iocorpus.py
@@ -8,6 +8,9 @@ class IOPair:
     mr: Any
     text: str
 
+    def __getitem__(self, item):
+        return self.__getattribute__(self.__slots__[item])
+
     def __iter__(self):
         return iter((self.mr, self.text))
 

--- a/enunlg/data_management/neural_methodius.py
+++ b/enunlg/data_management/neural_methodius.py
@@ -2,6 +2,8 @@ import csv
 import os
 
 from collections import namedtuple
+
+import omegaconf
 from pyparsing import alphanums, Forward, OneOrMore, Suppress, Word, ZeroOrMore
 from typing import Iterable, List, Optional, Tuple
 
@@ -11,7 +13,7 @@ import enunlg.data_management.iocorpus as iocorpus
 
 # TODO add hydra configuration for neural methodius stuff!
 NEURAL_METHODIUS_DIR = os.path.join(os.path.dirname(__file__), '../../datasets/methodiusNeuralINLG2021/corpus/')
-NEURAL_METHODIUS_CONFIG = box.Box({'NEURAL_METHODIUS_DIR': NEURAL_METHODIUS_DIR})
+NEURAL_METHODIUS_CONFIG = omegaconf.DictConfig({'NEURAL_METHODIUS_DIR': NEURAL_METHODIUS_DIR})
 NEURAL_METHODIUS_SPLITS = ('train_without_few', 'valid', 'test')
 
 RSTNode = namedtuple("Node", ["value", "children"])
@@ -70,7 +72,7 @@ def load_neural_methodius_tsv(filepath: str) -> List[Tuple[str, str]]:
 
 
 def load_neural_methodius(splits: Optional[Iterable[str]] = None,
-                          neural_methodius_config: Optional[box.Box] = None) -> MethodiusCorpus:
+                          neural_methodius_config: Optional[omegaconf.DictConfig] = None) -> MethodiusCorpus:
     """
 
     :param splits: which splits to load

--- a/enunlg/data_management/pipelinecorpus.py
+++ b/enunlg/data_management/pipelinecorpus.py
@@ -1,43 +1,14 @@
 from typing import Callable, Iterable, List, Optional, Union
 
-import lxml.etree
-
 import enunlg.data_management.iocorpus
 
 
 class PipelineCorpus(enunlg.data_management.iocorpus.IOCorpus):
-    def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None, validation_schema: Optional[str] = None, entry_class: Optional[Callable] = None):
-        if seq is None:
-            seq = []
+    def __init__(self, seq: Optional[Iterable] = None, metadata: Optional[dict] = None):
         super().__init__(seq)
-        self.entries = []
-        if validation_schema is not None:
-            self.validation_schema_doc = lxml.etree.parse(validation_schema)
-        if entry_class is not None:
-            self.entry_class = entry_class
-        if filename_or_list is not None:
-            if isinstance(filename_or_list, list):
-                for filename in filename_or_list:
-                    self.load_file(filename)
-            elif isinstance(filename_or_list, str):
-                    with open(filename_or_list, 'rb') as fs:
-                        self.validate(fs)
-                        self.add_entries_from_file(fs)
-            else:
-                raise TypeError(f"Expected filename_or_list to be None, str, or list, not {type(filename_or_list)}")
-
-    def load_file(self, filename):
-        with open(filename, 'rb') as fs:
-            if self.validate(fs):
-                self.add_entries_from_file(fs)
-            else:
-                raise ValueError(f"Invalid xml file: {filename}")
-
-    def validate(self, filestream):
-        self.validation_schema_doc.validate(filestream)
-
-    def add_entries_from_file(self, filestream) -> None:
-        entries_xml = lxml.etree.parse(filestream).getroot()
-        entries_xml = entries_xml.findall(".//entry")
-        for entry_xml in entries_xml:
-            self.entries.append(self.entry_class(entry_xml))
+        if metadata is None:
+            self.metadata = {'name': None,
+                             'splits': None,
+                             'directory': None,
+                             'annotation_layers': None
+                             }

--- a/enunlg/data_management/pipelinecorpus.py
+++ b/enunlg/data_management/pipelinecorpus.py
@@ -1,0 +1,43 @@
+from typing import Callable, Iterable, List, Optional, Union
+
+import lxml.etree
+
+import enunlg.data_management.iocorpus
+
+
+class PipelineCorpus(enunlg.data_management.iocorpus.IOCorpus):
+    def __init__(self, seq: Optional[Iterable] = None, filename_or_list: Optional[Union[str, List[str]]] = None, validation_schema: Optional[str] = None, entry_class: Optional[Callable] = None):
+        if seq is None:
+            seq = []
+        super().__init__(seq)
+        self.entries = []
+        if validation_schema is not None:
+            self.validation_schema_doc = lxml.etree.parse(validation_schema)
+        if entry_class is not None:
+            self.entry_class = entry_class
+        if filename_or_list is not None:
+            if isinstance(filename_or_list, list):
+                for filename in filename_or_list:
+                    self.load_file(filename)
+            elif isinstance(filename_or_list, str):
+                    with open(filename_or_list, 'rb') as fs:
+                        self.validate(fs)
+                        self.add_entries_from_file(fs)
+            else:
+                raise TypeError(f"Expected filename_or_list to be None, str, or list, not {type(filename_or_list)}")
+
+    def load_file(self, filename):
+        with open(filename, 'rb') as fs:
+            if self.validate(fs):
+                self.add_entries_from_file(fs)
+            else:
+                raise ValueError(f"Invalid xml file: {filename}")
+
+    def validate(self, filestream):
+        self.validation_schema_doc.validate(filestream)
+
+    def add_entries_from_file(self, filestream) -> None:
+        entries_xml = lxml.etree.parse(filestream).getroot()
+        entries_xml = entries_xml.findall(".//entry")
+        for entry_xml in entries_xml:
+            self.entries.append(self.entry_class(entry_xml))

--- a/enunlg/encdec/sclstm.py
+++ b/enunlg/encdec/sclstm.py
@@ -8,12 +8,12 @@ if TYPE_CHECKING:
     import enunlg.embeddings.onehot
 
 import random
+
+import omegaconf
 import torch
 import torch.jit
 import torch.nn
 import torch.nn.functional
-
-import box
 
 import enunlg.embeddings.glove
 
@@ -265,15 +265,15 @@ class SCLSTMLayer(torch.nn.Module):
         return torch.stack(outputs), state
 
 
-SCLSTM_DESCRIBED_CONFIG = box.Box({"name": "sclstm",
-                                   "mr_size": 24,  # based on Wen et al. SFX Restaurant data
-                                   "embeddings":
-                                       {"mode": "random",  # could also be one-hot, word2vec, glove, zero, etc
-                                        "dimensions": 80,
-                                        "backprop": True
-                                        },
-                                   "num_hidden_dims": 80
-                                   })
+SCLSTM_DESCRIBED_CONFIG = omegaconf.DictConfig({"name": "sclstm",
+                                                "mr_size": 24,  # based on Wen et al. SFX Restaurant data
+                                                "embeddings":
+                                                    {"mode": "random",  # could also be one-hot, word2vec, glove, zero, etc
+                                                     "dimensions": 80,
+                                                    "backprop": True
+                                                     },
+                                                "num_hidden_dims": 80
+                                                })
 SCLSTM_RELEASED_CONFIG = SCLSTM_DESCRIBED_CONFIG
 del SCLSTM_RELEASED_CONFIG.mr_size
 # based on Wen et al. SFX Restaurant data, as above

--- a/enunlg/encdec/seq2seq.py
+++ b/enunlg/encdec/seq2seq.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-import box
-
+import omegaconf
 import torch
 import torch.nn
 import torch.nn.functional
@@ -126,26 +125,26 @@ class TGenEncDec(torch.nn.Module):
         super().__init__()
         if model_config is None:
             # Set defaults
-            model_config = box.Box({'name': 'tgen',
-                                    'max_input_length': 30,
-                                    'encoder':
-                                        {'embeddings':
-                                            {'mode': 'random',
-                                             'dimensions': 50,
-                                             'backprop': True
-                                             },
-                                         'cell': 'lstm',
-                                         'num_hidden_dims': 50},
-                                    'decoder':
-                                        {'embeddings':
-                                            {'mode': 'random',
-                                             'dimensions': 50,
-                                             'backprop': True
-                                             },
-                                         'cell': 'lstm',
-                                         'num_hidden_dims': 50
-                                         }
-                                    })
+            model_config = omegaconf.DictConfig({'name': 'tgen',
+                                                 'max_input_length': 30,
+                                                 'encoder':
+                                                     {'embeddings':
+                                                          {'mode': 'random',
+                                                           'dimensions': 50,
+                                                           'backprop': True
+                                                           },
+                                                      'cell': 'lstm',
+                                                      'num_hidden_dims': 50},
+                                                 'decoder':
+                                                     {'embeddings':
+                                                          {'mode': 'random',
+                                                           'dimensions': 50,
+                                                           'backprop': True
+                                                           },
+                                                      'cell': 'lstm',
+                                                      'num_hidden_dims': 50
+                                                      }
+                                                 })
         self.config = model_config
 
         # Set basic properties

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -15,24 +15,9 @@ class EnrichedE2ESlotValuePair:
     class Meta:
         name = "inputType"
 
-    attribute: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    tag: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    value: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
+    attribute: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    tag: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    value: Optional[str] = field(default=None,metadata={"type": "Attribute"})
 
 
 @dataclass
@@ -87,6 +72,10 @@ class EnrichedE2ETarget:
     class Meta:
         name = "targetType"
 
+    annotator: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    comment: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    lid: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    ref: Optional[str] = field(default=None, metadata={"type": "Attribute"})
     structuring: Optional[EnrichedE2EContentPlan] = field(
         default=None,
         metadata={
@@ -115,30 +104,6 @@ class EnrichedE2ETarget:
             "required": True,
         }
     )
-    annotator: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    comment: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    lid: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    ref: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
 
 
 @dataclass
@@ -146,6 +111,8 @@ class EnrichedE2EEntry:
     class Meta:
         name = "entryType"
 
+    eid: Optional[str] = field(default=None, metadata={"type": "Attribute"})
+    size: Optional[str] = field(default=None, metadata={"type": "Attribute"})
     source: Optional[EnrichedE2ESource] = field(
         default=None,
         metadata={
@@ -157,18 +124,6 @@ class EnrichedE2EEntry:
         default_factory=list,
         metadata={
             "type": "Element",
-        }
-    )
-    eid: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-        }
-    )
-    size: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
         }
     )
 

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -1,0 +1,184 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class EnrichedE2ESlotValuePair:
+    class Meta:
+        name = "inputType"
+
+    attribute: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    tag: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    value: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class EnrichedE2ESentenceGrouping:
+    class Meta:
+        name = "sentenceType"
+
+    content: List[object] = field(
+        default_factory=list,
+        metadata={
+            "type": "Wildcard",
+            "namespace": "##any",
+            "mixed": True,
+            "choices": (
+                {
+                    "name": "input",
+                    "type": EnrichedE2ESlotValuePair,
+                },
+            ),
+        }
+    )
+
+
+@dataclass
+class EnrichedE2ESource:
+    class Meta:
+        name = "sourceType"
+
+    input: List[EnrichedE2ESlotValuePair] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+        }
+    )
+
+
+@dataclass
+class EnrichedE2EContentPlan:
+    class Meta:
+        name = "structuringType"
+
+    sentence: List[EnrichedE2ESentenceGrouping] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+        }
+    )
+
+
+@dataclass
+class EnrichedE2ETarget:
+    class Meta:
+        name = "targetType"
+
+    structuring: Optional[EnrichedE2EContentPlan] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    text: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    template: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    lexicalization: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    annotator: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    comment: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    lid: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    ref: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class EnrichedE2EEntry:
+    class Meta:
+        name = "entryType"
+
+    source: Optional[EnrichedE2ESource] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    target: List[EnrichedE2ETarget] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+        }
+    )
+    eid: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    size: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class EnrichedE2EEntries:
+    class Meta:
+        name = "entriesType"
+
+    entry: List[EnrichedE2EEntry] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+        }
+    )
+
+
+@dataclass
+class Entries(EnrichedE2EEntries):
+    class Meta:
+        name = "entries"

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 @dataclass(frozen=True)
 class EnrichedE2ESlotValuePair:
     class Meta:
-        name = "inputType"
+        name = "input"
 
     attribute: Optional[str] = field(default=None, metadata={"type": "Attribute"})
     tag: Optional[str] = field(default=None, metadata={"type": "Attribute"})
@@ -23,7 +23,7 @@ class EnrichedE2ESlotValuePair:
 @dataclass
 class EnrichedE2ESentenceGrouping:
     class Meta:
-        name = "sentenceType"
+        name = "sentence"
 
     content: List[object] = field(
         default_factory=list,
@@ -44,12 +44,14 @@ class EnrichedE2ESentenceGrouping:
 @dataclass
 class EnrichedE2ESource:
     class Meta:
-        name = "sourceType"
+        name = "source"
 
-    input: List[EnrichedE2ESlotValuePair] = field(
+    inputs: List[EnrichedE2ESlotValuePair] = field(
         default_factory=list,
         metadata={
+            "name": "input",
             "type": "Element",
+            "min_occurs": 1
         }
     )
 
@@ -57,12 +59,14 @@ class EnrichedE2ESource:
 @dataclass
 class EnrichedE2EContentPlan:
     class Meta:
-        name = "structuringType"
+        name = "structuring"
 
-    sentence: List[EnrichedE2ESentenceGrouping] = field(
+    sentences: List[EnrichedE2ESentenceGrouping] = field(
         default_factory=list,
         metadata={
+            "name": "sentence",
             "type": "Element",
+            "min_occurs": 1
         }
     )
 
@@ -70,7 +74,7 @@ class EnrichedE2EContentPlan:
 @dataclass
 class EnrichedE2ETarget:
     class Meta:
-        name = "targetType"
+        name = "target"
 
     annotator: Optional[str] = field(default=None, metadata={"type": "Attribute"})
     comment: Optional[str] = field(default=None, metadata={"type": "Attribute"})
@@ -109,7 +113,7 @@ class EnrichedE2ETarget:
 @dataclass
 class EnrichedE2EEntry:
     class Meta:
-        name = "entryType"
+        name = "entry"
 
     eid: Optional[str] = field(default=None, metadata={"type": "Attribute"})
     size: Optional[str] = field(default=None, metadata={"type": "Attribute"})
@@ -117,13 +121,15 @@ class EnrichedE2EEntry:
         default=None,
         metadata={
             "type": "Element",
-            "required": True,
+            "required": True
         }
     )
-    target: List[EnrichedE2ETarget] = field(
+    targets: List[EnrichedE2ETarget] = field(
         default_factory=list,
         metadata={
+            "name": "target",
             "type": "Element",
+            "min_occurs": 1
         }
     )
 
@@ -131,11 +137,12 @@ class EnrichedE2EEntry:
 @dataclass
 class EnrichedE2EEntries:
     class Meta:
-        name = "entriesType"
+        name = "entries"
 
-    entry: List[EnrichedE2EEntry] = field(
+    entries: List[EnrichedE2EEntry] = field(
         default_factory=list,
         metadata={
+            "name": "entry",
             "type": "Element",
         }
     )

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -1,3 +1,11 @@
+"""
+IO data classes for the EnrichedE2E dataset.
+
+Use dataclasses.asdict() to get a JSON-able dict from this.
+Use xsdata.formats.dataclass.serializers.XmlSerializer() to generate XML outputs from this.
+"""
+
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -139,9 +139,3 @@ class EnrichedE2EEntries:
             "type": "Element",
         }
     )
-
-
-@dataclass
-class Entries(EnrichedE2EEntries):
-    class Meta:
-        name = "entries"

--- a/enunlg/formats/xml/enriched_e2e.py
+++ b/enunlg/formats/xml/enriched_e2e.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 
-@dataclass
+@dataclass(frozen=True)
 class EnrichedE2ESlotValuePair:
     class Meta:
         name = "inputType"

--- a/enunlg/formats/xml/enriched_webnlg.py
+++ b/enunlg/formats/xml/enriched_webnlg.py
@@ -1,0 +1,378 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Dbpedialink:
+    class Meta:
+        name = "dbpedialink"
+
+    direction: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    value: str = field(
+        default="",
+        metadata={
+            "required": True,
+        }
+    )
+
+
+
+@dataclass
+class Link:
+    class Meta:
+        name = "link"
+
+    direction: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    value: str = field(
+        default="",
+        metadata={
+            "required": True,
+        }
+    )
+
+
+
+@dataclass
+class Dbpedialinks:
+    class Meta:
+        name = "dbpedialinks"
+
+    dbpedialink: List[Dbpedialink] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class Links:
+    class Meta:
+        name = "links"
+
+    link: List[Link] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class EntityMap:
+    """EnrichedWebNLG-style mapping from entity placeholders to the canonical forms for the entities they refer to."""
+    class Meta:
+        name = "entitymap"
+
+    entity: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class ModifiedTripleSet:
+    """WebNLG-style set of RDF triples which have been modified, typically by a normalisation process"""
+    class Meta:
+        name = "modifiedtripleset"
+
+    mtriple: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class OriginalTripleSet:
+    """WebNLG-style set of RDF triples, as taken from DBPedia"""
+    class Meta:
+        name = "originaltripleset"
+
+    otriple: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class SentenceGrouping:
+    """EnrichedWebNLG-style set of triples which should be expressed in a single sentence."""
+    class Meta:
+        name = "sentence"
+
+    id: Optional[int] = field(
+        default=None,
+        metadata={
+            "name": "ID",
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    striple: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+        }
+    )
+
+
+@dataclass
+class SortedTripleSet:
+    """EnrichedWebNLG-style set of RDF triples where the order has been fixed (i.e. they have been sorted somehow)"""
+    class Meta:
+        name = "sortedtripleset"
+
+    sentence: List[SentenceGrouping] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class Lex:
+    """WebNLG-style files use <lex> elements for all the information relating to a particular surface realisation."""
+    class Meta:
+        name = "lex"
+
+    comment: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    lang: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": False,
+        }
+    )
+    lid: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    tree: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+            "sequence": 1,
+        }
+    )
+    sortedtripleset: List[SortedTripleSet] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+            "sequence": 1,
+        }
+    )
+    references: List[object] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+            "sequence": 1,
+        }
+    )
+    text: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+            "sequence": 1,
+        }
+    )
+    template: List[str] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+            "sequence": 1,
+        }
+    )
+    value: str = field(
+        default="",
+        metadata={
+            "required": True,
+        }
+    )
+
+
+@dataclass
+class EnrichedWebNLGEntry:
+    """
+    (Enriched) WebNLG-style entry
+
+    Attributes
+    --------
+    category:
+        The DBPedia category for this entry
+    eid:
+
+    size:
+
+    originaltripleset:
+
+    modifiedtripleset:
+
+    lex:
+
+    entitymap:
+        Only present in EnrichedWebNLG datasets
+    """
+    class Meta:
+        name = "entry"
+
+    category: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    eid: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    shape: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    shape_type: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    size: Optional[int] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    originaltripleset: List[OriginalTripleSet] = field(
+        default=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+    modifiedtripleset: Optional[ModifiedTripleSet] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+    lex: List[Lex] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+    entitymap: Optional[EntityMap] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )
+
+    dbpedialinks: Optional[Dbpedialinks] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+        }
+    )
+    links: Optional[Links] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+        }
+    )
+
+@dataclass
+class EnrichedWebNLGEntries:
+    """
+    WebNLG-style files contain a set of <entries> comprising the <benchmark>
+
+    Note the odd name, that the attribute storing the list of entries is called "entry" rather than "entries";
+    this is an artefact of the library we're using to parse XML to dataclasses
+
+    Attributes
+    ----
+    entry:
+        "list of entries for the parent benchmark
+    """
+    class Meta:
+        name = "entries"
+
+    entry: List[EnrichedWebNLGEntry] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )
+
+
+@dataclass
+class EnrichedWebNLGBenchmark:
+    """
+    WebNLG-style files use <benchmark> as the root element.
+
+    Attributes
+    --------
+    entries:
+        the (possibly empty) (XML) element for containing the entries for this WebNLGBenchmark.
+    """
+    class Meta:
+        name = "benchmark"
+
+    entries: Optional[EnrichedWebNLGEntries] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "required": True,
+        }
+    )

--- a/enunlg/meaning_representation/slot_value.py
+++ b/enunlg/meaning_representation/slot_value.py
@@ -11,3 +11,15 @@ class SlotValueMR(box.Box):
 
     def __str__(self):
         return self.__repr__()
+
+
+class MultivaluedSlotValueMR(box.Box):
+    def __init__(self, *args, **kwargs):
+        super(SlotValueMR, self).__init__(*args, default_box=True, default_box_attr=list, **kwargs)
+
+    def __repr__(self):
+        slot_value_pairs = ", ".join([f"{key}='{self[key]}'" for key in self.keys()])
+        return f"{self.__class__.__name__}({slot_value_pairs})"
+
+    def __str__(self):
+        return self.__repr__()

--- a/enunlg/meaning_representation/slot_value.py
+++ b/enunlg/meaning_representation/slot_value.py
@@ -1,0 +1,13 @@
+import box
+
+
+class SlotValueMR(box.Box):
+    def __init__(self, *args, **kwargs):
+        super(SlotValueMR, self).__init__(*args, **kwargs)
+
+    def __repr__(self):
+        slot_value_pairs = ", ".join([f"{key}='{self[key]}'" for key in self.keys()])
+        return f"{self.__class__.__name__}({slot_value_pairs})"
+
+    def __str__(self):
+        return self.__repr__()

--- a/enunlg/nlu/binary_mr_classifier.py
+++ b/enunlg/nlu/binary_mr_classifier.py
@@ -7,7 +7,7 @@ from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     import enunlg.embeddings.onehot
 
-import box
+import omegaconf
 import torch
 import torch.nn
 
@@ -21,7 +21,7 @@ class TGenSemClassifier(torch.nn.Module):
         super().__init__()
         if model_config is None:
             # Set defaults
-            model_config = box.Box({'name': 'tgen_classifier',
+            model_config = omegaconf.DictConfig({'name': 'tgen_classifier',
                                     'max_mr_length': 30,
                                     'text_encoder':
                                         {'embeddings':

--- a/enunlg/pipelines/lookup_pipeline.py
+++ b/enunlg/pipelines/lookup_pipeline.py
@@ -1,8 +1,10 @@
+from dataclasses import asdict
+
 import enunlg.data_management.enriched_e2e as ee2e
 import enunlg.templates.lookup as lug
 
 
 if __name__ == "__main__":
-    corpus = ee2e.load_enriched_e2e(splits=("train", ))
-    for x in corpus.entries[:5]:
+    corpus = ee2e.load_enriched_e2e(splits=("dev", ))
+    for x in corpus[:6]:
         print(x)

--- a/enunlg/pipelines/lookup_pipeline.py
+++ b/enunlg/pipelines/lookup_pipeline.py
@@ -1,10 +1,39 @@
 from dataclasses import asdict
 
+import logging
+logging.basicConfig(encoding='utf-8', level=logging.INFO)
+
 import enunlg.data_management.enriched_e2e as ee2e
 import enunlg.templates.lookup as lug
+
+
+class PipelineLookupGenerator(object):
+    def __init__(self, corpus: ee2e.EnrichedE2ECorpus):
+        self.layers = corpus.layers
+        self.pipeline = corpus.views
+        self.modules = {layer_pair: lug.OneToManyLookupGenerator() for layer_pair in self.pipeline}
+        for layer_pair in self.modules:
+            self.modules[layer_pair].train(corpus.items_by_view(layer_pair))
+
+    def predict(self, mr):
+        curr_input = mr
+        for layer_pair in self.modules:
+            logging.debug(layer_pair)
+            logging.debug(curr_input)
+            curr_output = self.modules[layer_pair].predict(curr_input)
+            logging.debug(curr_output)
+            curr_input = curr_output
+        return curr_output
 
 
 if __name__ == "__main__":
     corpus = ee2e.load_enriched_e2e(splits=("dev", ))
     for x in corpus[:6]:
         print(x)
+
+    plg = PipelineLookupGenerator(corpus)
+    for entry in corpus:
+        mr = entry.raw_input
+        print(mr)
+        print(plg.predict(mr))
+        print("----")

--- a/enunlg/pipelines/lookup_pipeline.py
+++ b/enunlg/pipelines/lookup_pipeline.py
@@ -1,0 +1,8 @@
+import enunlg.data_management.enriched_e2e as ee2e
+import enunlg.templates.lookup as lug
+
+
+if __name__ == "__main__":
+    corpus = ee2e.load_enriched_e2e(splits=("train", ))
+    for x in corpus.entries[:5]:
+        print(x)

--- a/enunlg/templates/lookup.py
+++ b/enunlg/templates/lookup.py
@@ -1,7 +1,7 @@
 """Lookup templates use MRs as keys and texts as values."""
 
 from collections import defaultdict
-from typing import Hashable, Iterable, Tuple
+from typing import Any, Hashable, Iterable, Tuple
 
 import abc
 import random
@@ -12,7 +12,7 @@ class LookupGenerator(abc.ABC):
     def _add_io_pair(self, pair) -> None:
         pass
 
-    def train(self, pairs: Iterable[Tuple[Hashable, str]]) -> None:
+    def train(self, pairs: Iterable[Tuple[Hashable, Any]]) -> None:
         for pair in pairs:
             self._add_io_pair(pair)
 
@@ -31,10 +31,10 @@ class OneToOneLookupGenerator(LookupGenerator):
         """
         self._mapping = {}
 
-    def _add_io_pair(self, io_pair: Tuple[Hashable, str]) -> None:
+    def _add_io_pair(self, io_pair: Tuple[Hashable, Any]) -> None:
         self._mapping[io_pair[0]] = io_pair[1]
 
-    def train(self, pairs: Iterable[Tuple[Hashable, str]]) -> None:
+    def train(self, pairs: Iterable[Tuple[Hashable, Any]]) -> None:
         for pair in pairs:
             self._add_io_pair(pair)
 
@@ -52,8 +52,8 @@ class OneToManyLookupGenerator(LookupGenerator):
         """
         self._mapping = defaultdict(list)
 
-    def _add_io_pair(self, io_pair: Tuple[Hashable, str]) -> None:
+    def _add_io_pair(self, io_pair: Tuple[Hashable, Any]) -> None:
         self._mapping[io_pair[0]].append(io_pair[1])
 
-    def predict(self, mr: Hashable) -> str:
+    def predict(self, mr: Hashable) -> Any:
         return random.choice(self._mapping[mr])

--- a/enunlg/trainer.py
+++ b/enunlg/trainer.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-import box
+import omegaconf
 import sacrebleu.metrics as sm
 import torch
 
@@ -65,14 +65,14 @@ class SCLSTMTrainer(BasicTrainer):
                  training_config=None):
         if training_config is None:
             # Set defaults
-            training_config = box.Box({"num_epochs": 20,
-                                    "record_interval": 519,
-                                    "shuffle": True,
-                                    "batch_size": 1,
-                                    "optimizer": "sgd",
-                                    "learning_rate": 0.1,
-                                    "learning_rate_decay": 0.5
-                                       })
+            training_config = omegaconf.DictConfig({"num_epochs": 20,
+                                                    "record_interval": 519,
+                                                    "shuffle": True,
+                                                    "batch_size": 1,
+                                                    "optimizer": "sgd",
+                                                    "learning_rate": 0.1,
+                                                    "learning_rate_decay": 0.5
+                                                    })
         super().__init__(model, training_config)
 
         # Re-initialize loss using summation instead of mean
@@ -131,14 +131,14 @@ class TGenTrainer(BasicTrainer):
                  training_config=None):
         if training_config is None:
             # Set defaults
-            training_config = box.Box({"num_epochs": 20,
-                                    "record_interval": 1000,
-                                    "shuffle": True,
-                                    "batch_size": 1,
-                                    "optimizer": "adam",
-                                    "learning_rate": 0.0005,
-                                    "learning_rate_decay": 0.5 # TGen used 0.0
-                                    })
+            training_config = omegaconf.DictConfig({"num_epochs": 20,
+                                                    "record_interval": 1000,
+                                                    "shuffle": True,
+                                                    "batch_size": 1,
+                                                    "optimizer": "adam",
+                                                    "learning_rate": 0.0005,
+                                                    "learning_rate_decay": 0.5 # TGen used 0.0
+                                                   })
         super().__init__(model, training_config)
         self._early_stopping_scores = [float('-inf')] * 5
         self._early_stopping_scores_changed = -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pytorch-beam-search = "^1.2.2"
 sacrebleu = "^2.3.1"
 scalene = "^1.5.13"
 lxml = "^4.9.2"
+xsdata = "^23.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/scripts/lookup_generator.py
+++ b/scripts/lookup_generator.py
@@ -1,9 +1,9 @@
 import enunlg.data_management.e2e_challenge as e2e
-import enunlg as lug
+import enunlg.templates.lookup as lug
 
 if __name__ == "__main__":
     print("Loading E2E Challenge Data")
-    splits =('trainset', )
+    splits = ('trainset', )
     e2e_corpus = e2e.load_e2e(splits)
     print("----")
     print("Training a one-to-many lookup generator")

--- a/tests/formats/xml/test_webnlg.py
+++ b/tests/formats/xml/test_webnlg.py
@@ -1,0 +1,23 @@
+import os
+
+import xsdata.exceptions
+import xsdata.formats.dataclass.parsers as xsparsers
+
+from enunlg.formats.xml.enriched_webnlg import EnrichedWebNLGBenchmark
+
+webnlg_directories = ["datasets/raw/2023-Challenge/data", "datasets/raw/webnlg/data/v2.0/en/train"]
+
+for directory in webnlg_directories:
+    print(directory)
+    if os.path.exists(directory):
+        print(directory)
+        filenames = [os.path.join(directory, filename) for filename in os.listdir(directory) if filename.endswith(".xml")]
+        for fn in filenames:
+            try:
+                xsparsers.XmlParser().parse(fn, EnrichedWebNLGBenchmark)
+            except xsdata.exceptions.ParserError as e:
+                print(e.args)
+                print(fn)
+                raise
+
+


### PR DESCRIPTION
this includes not just the changes for loading pipeline annotated datasets, but also provides an example of their usage with a 'lookup generator'.

one change that would have been better as its own PR is the shift from using box.Box to using omegaconf.DictConfig to represent default configs for various classes. This makes the types more consistent for configs in general (since we're always using something based on omegaconf).

In the future, we should switch from box.Box for MRs to our own subclasses, to avoid confusion about the capabilities of these MRs.