### PR TITLE
bugfix: correct format for calling bleu scoring

### DIFF
--- a/enunlg/trainer.py
+++ b/enunlg/trainer.py
@@ -202,7 +202,8 @@ class TGenTrainer(BasicTrainer):
             ref_outputs.append(self.model.output_vocab.pretty_string(out_indices.tolist()))
         # Calculate BLEU compared to targets
         bleu = sm.BLEU()
-        bleu_score = bleu.corpus_score(best_outputs, ref_outputs)
+        # We only have one reference per output
+        bleu_score = bleu.corpus_score(best_outputs, [ref_outputs])
         logging.info(f"Current score: {bleu_score}")
         if bleu_score.score > self._early_stopping_scores[-1]:
             self._early_stopping_scores.append(bleu_score.score)


### PR DESCRIPTION
sacrebleu expects the list of lists to be such that the Nth list corresponds to the Nth reference for every item, instead of having a list where each item is a list of the references corresponding tot he Nth item.